### PR TITLE
error on reading file for compare

### DIFF
--- a/s3funnel/jobs.py
+++ b/s3funnel/jobs.py
@@ -115,7 +115,7 @@ class PutJob(Job):
         data = fp.read(READ_CHUNK)
         while data:
             hash.update(data)
-            data = read(READ_CHUNK)
+            data = fp.read(READ_CHUNK)
         fp.close()
         digest = hash.hexdigest()
 


### PR DESCRIPTION
when run with the --put-only-new option there is an error encountered when the file is loaded to calculate it's md5 digest.
