### PR TITLE
import time module so sleep-on-boto-error works properly.

### DIFF
--- a/s3funnel/__init__.py
+++ b/s3funnel/__init__.py
@@ -2,6 +2,7 @@ import logging
 log = logging.getLogger(__name__)
 
 import boto
+import time
 import workerpool
 
 from boto.exception import BotoServerError, BotoClientError, S3ResponseError


### PR DESCRIPTION
time.sleep() is used in a function but was never imported.
